### PR TITLE
Add Traefik CORS Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ http:
     materialious:
       headers:
         accessControlAllowCredentials: true
-        accessControlAllowOrigin: "https://materialious.example.com"
+        accessControlAllowOriginList: "https://materialious.example.com"
         accessControlAllowMethods:
           - GET
           - POST
@@ -110,7 +110,6 @@ http:
           - Authorization 
           - Content-Type
 ```
-
 
 ### Other
 Please open a PR request or issue if you implement this in a different reverse proxy.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,30 @@ server {
 }
 ```
 
+### Traefik example
+Add this middleware to your Invidious instance:
+```yaml
+http:
+  middlewares:
+    materialious:
+      headers:
+        accessControlAllowCredentials: true
+        accessControlAllowOrigin: "https://materialious.example.com"
+        accessControlAllowMethods:
+          - GET
+          - POST
+          - OPTIONS
+          - HEAD
+          - PATCH
+          - PUT
+          - DELETE
+        accessControlAllowHeaders: 
+          - User-Agent
+          - Authorization 
+          - Content-Type
+```
+
+
 ### Other
 Please open a PR request or issue if you implement this in a different reverse proxy.
 


### PR DESCRIPTION
Thanks for making this, it's great having a self hosted Invidious instance but it's certainly not the prettiest so love this project, but as I use Traefik I noticed there wasn't an example to enable me to easily get it working.  Using your nginx example have managed to get it all working with Traefik v2.11.0, so thought I'd submit a PR to the docs.

