### PR TITLE
Add Padding, ignore lockfiles, and added material-dynamic-colors package.

### DIFF
--- a/materialious/.gitignore
+++ b/materialious/.gitignore
@@ -3,6 +3,11 @@ node_modules
 /build
 /.svelte-kit
 /package
+# Lock files of most package managers
+bun.lockb
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
 .env
 .env.*
 !.env.example

--- a/materialious/package.json
+++ b/materialious/package.json
@@ -38,6 +38,7 @@
 		"beercss": "^3.5.1",
 		"fuse.js": "^7.0.0",
 		"human-number": "^2.0.4",
+		"material-dynamic-colors": "^1.1.0",
 		"media-icons": "^0.10.0",
 		"peerjs": "^1.5.2",
 		"sponsorblock-api": "^0.2.4",

--- a/materialious/src/routes/+error.svelte
+++ b/materialious/src/routes/+error.svelte
@@ -7,7 +7,7 @@
 
 <div class="space"></div>
 
-<div class="centervertical" style="display: flex;align-items: center;flex-direction: column;text-align: center;padding: 90px;">
+<div style="display: flex;align-items: center;flex-direction: column;text-align: center;padding: 90px;">
 	<svg xmlns="http://www.w3.org/2000/svg" height="200" viewBox="0 -960 960 960" width="200"
 		><path
 			d="M480-420q-68 0-123.5 38.5T276-280h408q-25-63-80.5-101.5T480-420Zm-168-60 44-42 42 42 42-42-42-42 42-44-42-42-42 42-44-42-42 42 42 44-42 42 42 42Zm250 0 42-42 44 42 42-42-42-42 42-44-42-42-44 42-42-42-42 42 42 44-42 42 42 42ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-400Zm0 320q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Z"

--- a/materialious/src/routes/+error.svelte
+++ b/materialious/src/routes/+error.svelte
@@ -7,13 +7,13 @@
 
 <div class="space"></div>
 
-<div style="display: flex;align-items: center;flex-direction: column;">
+<div class="centervertical" style="display: flex;align-items: center;flex-direction: column;text-align: center;padding: 90px;">
 	<svg xmlns="http://www.w3.org/2000/svg" height="200" viewBox="0 -960 960 960" width="200"
 		><path
 			d="M480-420q-68 0-123.5 38.5T276-280h408q-25-63-80.5-101.5T480-420Zm-168-60 44-42 42 42 42-42-42-42 42-44-42-42-42 42-44-42-42 42 42 44-42 42 42 42Zm250 0 42-42 44 42 42-42-42-42 42-44-42-42-44 42-42-42-42 42 42 44-42 42 42 42ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-400Zm0 320q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Z"
 		/></svg
 	>
-	<h2>Oh no! You've encountered a error.</h2>
+	<h2>Oh no! You've encountered an error.</h2>
 
 	<a
 		href="https://github.com/WardPearce/Materialious/issues/new"


### PR DESCRIPTION
Add padding to the top of the error page so that it doesn't get hidden  by other components. Added more ignored lockfiles, and added the material-dynamic-colors package since it wasn't installed by default.